### PR TITLE
fix: end node spans at the value's last token for byte-minimal edits

### DIFF
--- a/.changeset/tidy-otters-parse.md
+++ b/.changeset/tidy-otters-parse.md
@@ -1,0 +1,8 @@
+---
+"jsonc-effect": patch
+---
+
+## Bug Fixes
+
+- Fixed `parseTree` node spans running past trailing whitespace/comments to the next scanned token; offsets/lengths now end at the node's last token, so `findNodeAtOffset` and `getNodePath` resolve offsets in trailing trivia to the containing node instead of the preceding value (#62)
+- Fixed `modify` producing non-minimal edits: replacing a value no longer deletes the whitespace/newline between the value and a following `}`/`]`, and inserting a new property now appends `,\n<indent>"key": ...` directly after the last value instead of emitting the comma on its own line and dropping the newline before the closing brace

--- a/.claude/design/jsonc-effect/architecture.md
+++ b/.claude/design/jsonc-effect/architecture.md
@@ -3,8 +3,8 @@ status: current
 module: jsonc-effect
 category: architecture
 created: 2026-03-12
-updated: 2026-03-13
-last-synced: 2026-03-13
+updated: 2026-07-06
+last-synced: 2026-07-06
 completeness: 95
 related:
   - scanner.md
@@ -21,8 +21,7 @@ dependencies: []
 
 # jsonc-effect - Architecture Overview
 
-Pure Effect-TS implementation of a JSONC (JSON with Comments) parser with no external parser
-dependencies.
+Pure Effect-TS implementation of a JSONC (JSON with Comments) parser with no external parser dependencies.
 
 ## Table of Contents
 
@@ -39,14 +38,9 @@ dependencies.
 
 ## Overview
 
-jsonc-effect is a pure Effect-TS implementation of a JSONC (JSON with Comments) parser. The scanner,
-parser, AST construction, and formatting are all implemented natively -- the only runtime dependency
-is `effect`. Microsoft's jsonc-parser (MIT) serves as the design reference for token types, AST
-structure, and parser behavior, but it is not a dependency.
+jsonc-effect is a pure Effect-TS implementation of a JSONC (JSON with Comments) parser. The scanner, parser, AST construction and formatting are all implemented natively -- the only runtime dependency is `effect`. Microsoft's jsonc-parser (MIT) serves as the design reference for token types, AST structure and parser behavior, but it is not a dependency.
 
-The package provides three primary APIs: `parse` (JSONC string to JavaScript value), `parseTree`
-(JSONC string to AST), and `stripComments` (remove comments to produce valid JSON). All APIs return
-Effect values, enabling typed error handling and composition with other Effect-based code.
+The package provides three primary APIs: `parse` (JSONC string to JavaScript value), `parseTree` (JSONC string to AST), and `stripComments` (remove comments to produce valid JSON). All APIs return Effect values, enabling typed error handling and composition with other Effect-based code.
 
 **Key Design Principles:**
 
@@ -66,11 +60,7 @@ Effect values, enabling typed error handling and composition with other Effect-b
 
 ## Current State
 
-All implementation phases complete. GitHub Issues #1-#9 all closed.
-
-- **Tests:** 207 passing
-- **Coverage:** ~89% statements, ~82% branches, ~99% functions
-- **Branch:** `feat/implementation` (pushed, ready for PR)
+All implementation phases complete, including the tight node span fix for byte-minimal in-place edits (issue #62). See `src/index.test.ts` for the full test suite covering all modules.
 
 ### Source Structure
 
@@ -86,7 +76,7 @@ src/
   format.ts              # format, modify, applyEdits, formatAndApply
   equality.ts            # equals, equalsValue -- semantic JSONC comparison
   index.ts               # barrel exports
-  index.test.ts          # 207 tests covering all modules
+  index.test.ts          # tests covering all modules
 ```
 
 ### Component Summary
@@ -232,25 +222,21 @@ See individual design docs for detailed component documentation.
 
 ### Key Architectural Decisions
 
-1. **String literals for token types** -- Self-documenting debug output, natural JSON serialization,
-   readable test assertions. See [effect-patterns.md](effect-patterns.md) for Schema.Literal usage.
+1. **String literals for token types** -- Self-documenting debug output, natural JSON serialization, readable test assertions. See [effect-patterns.md](effect-patterns.md) for Schema.Literal usage.
 
-2. **Data.TaggedError with *Base exports** -- Required for api-extractor DTS compatibility. See
-   [error-types.md](error-types.md) for the pattern.
+2. **Data.TaggedError with *Base exports** -- Required for api-extractor DTS compatibility. See [error-types.md](error-types.md) for the pattern.
 
-3. **Schema.Class for data types** -- Structural equality, validation, and composable Schema
-   pipelines. See [effect-patterns.md](effect-patterns.md).
+3. **Schema.Class for data types** -- Structural equality, validation and composable Schema pipelines. See [effect-patterns.md](effect-patterns.md).
 
-4. **Error accumulation** -- Parser collects all errors rather than stopping at the first, similar
-   to IDE diagnostic reporting. See [parser.md](parser.md).
+4. **Error accumulation** -- Parser collects all errors rather than stopping at the first, similar to IDE diagnostic reporting. See [parser.md](parser.md).
 
-5. **allowTrailingComma defaults to true** -- Unlike Microsoft's jsonc-parser (defaults false),
-   because JSONC config files commonly use trailing commas.
+5. **allowTrailingComma defaults to true** -- Unlike Microsoft's jsonc-parser (defaults false), because JSONC config files commonly use trailing commas.
 
-6. **Pure functions, not services** -- Parsing is synchronous and stateless, so Effect services
-   would add unnecessary complexity. All public APIs use `Effect.sync` wrapping.
+6. **Pure functions, not services** -- Parsing is synchronous and stateless, so Effect services would add unnecessary complexity. All public APIs use `Effect.sync` wrapping.
 
 7. **Platform independent** -- No `node:` imports anywhere, enabling browser and edge runtime usage.
+
+8. **Tight node spans** -- `JsoncNode.offset`/`length` end at the node's last token, excluding trailing whitespace and comments, so `modify` can produce byte-minimal edits. See [parser.md](parser.md) and [formatting.md](formatting.md).
 
 ### Design Patterns
 
@@ -279,8 +265,7 @@ This is a single-package library, not a layered application. The architecture is
 - JavaScript values (when `buildTree=false`)
 - AST nodes as `JsoncNode` (when `buildTree=true`)
 
-**Effect layer:** Public API functions (`parse`, `parseTree`, `stripComments`) wrap the synchronous
-internals in `Effect.sync` and convert error arrays to `Effect.fail(JsoncParseError)`.
+**Effect layer:** Public API functions (`parse`, `parseTree`, `stripComments`) wrap the synchronous internals in `Effect.sync` and convert error arrays to `Effect.fail(JsoncParseError)`.
 
 ### Build Pipeline
 
@@ -321,8 +306,10 @@ Turbo orchestrates builds with task dependencies: `typecheck` depends on `build`
 
 ### Parse Tree Flow (JSONC String to AST)
 
+Node spans are tight: each `offset`/`length` ends at the node's last token, excluding trailing whitespace and comments (see [parser.md](parser.md)).
+
 ```text
-"{ \"key\": 42 }"
+'{ "key": 42 }'
        |
        v
   parseObjectTree()
@@ -330,11 +317,11 @@ Turbo orchestrates builds with task dependencies: `typecheck` depends on `build`
        v
   JsoncNode {
     type: "object",
-    offset: 0, length: 16,
+    offset: 0, length: 13,          // "{ \"key\": 42 }" — ends at "}"
     children: [
       JsoncNode {
         type: "property",
-        offset: 2, length: 12,
+        offset: 2, length: 9,       // "\"key\": 42" — ends at value's end
         colonOffset: 7,
         children: [
           JsoncNode { type: "string", value: "key", offset: 2, length: 5 },
@@ -348,23 +335,22 @@ Turbo orchestrates builds with task dependencies: `typecheck` depends on `build`
   Option.some(node) wrapped in Effect.succeed
 ```
 
-See [scanner.md](scanner.md) for token type details and [parser.md](parser.md) for the full
-parsing pipeline.
+See [scanner.md](scanner.md) for token type details and [parser.md](parser.md) for the full parsing pipeline.
 
 ---
 
 ## Testing Strategy
 
-207 tests organized into suites covering all modules:
+Tests are organized into suites covering all modules (see `src/index.test.ts`):
 
 - **Error types** -- `_tag` values, message formatting, structural equality
 - **Schema definitions** -- Schema.Class construction, defaults, recursive structure
 - **Scanner** -- All token types, escape sequences, unicode, comments, numbers, errors
-- **Parser** -- parse/parseTree for all value types, error accumulation, options
-- **Schema Integration** (14 tests) -- Round-trip, custom options, composed schemas
-- **AST Navigation** (11 tests) -- Path navigation, offset lookup, value reconstruction
-- **Visitor/Stream** (13 tests) -- Event emission, filtering, error events
-- **Formatting/Modification** (10 tests) -- Format, range format, modify, applyEdits
+- **Parser** -- parse/parseTree for all value types, error accumulation, options, tight node spans
+- **Schema Integration** -- Round-trip, custom options, composed schemas
+- **AST Navigation** -- Path navigation, offset lookup, value reconstruction
+- **Visitor/Stream** -- Event emission, filtering, error events
+- **Formatting/Modification** -- Format, range format, modify, applyEdits, byte-minimal edits
 
 **Configuration:**
 
@@ -387,7 +373,7 @@ parsing pipeline.
 **Component Design Docs:**
 
 - [Scanner](scanner.md) -- Lexer implementation and token types
-- [Parser](parser.md) -- Recursive descent parser, error accumulation
+- [Parser](parser.md) -- Recursive descent parser, error accumulation, tight node spans
 - [Schema Integration](schema-integration.md) -- transformOrFail pipelines
 - [AST Navigation](ast-navigation.md) -- findNode, findNodeAtOffset, getNodePath, getNodeValue
 - [Visitor](visitor.md) -- SAX-style event stream API

--- a/.claude/design/jsonc-effect/ast-navigation.md
+++ b/.claude/design/jsonc-effect/ast-navigation.md
@@ -3,8 +3,8 @@ status: current
 module: jsonc-effect
 category: architecture
 created: 2026-03-12
-updated: 2026-03-13
-last-synced: 2026-03-13
+updated: 2026-07-06
+last-synced: 2026-07-06
 completeness: 95
 related:
   - architecture.md
@@ -29,9 +29,7 @@ Pipe-friendly traversal utilities for `JsoncNode` trees produced by `parseTree()
 
 ## Overview
 
-The AST navigation module (`ast.ts`) provides functions for traversing and querying the parse tree
-produced by `parseTree()`. All functions support `Function.dual` for both data-first and data-last
-calling conventions, making them composable in Effect pipelines.
+The AST navigation module (`ast.ts`) provides functions for traversing and querying the parse tree produced by `parseTree()`. All functions support `Function.dual` for both data-first and data-last calling conventions, making them composable in Effect pipelines.
 
 **When to reference this document:**
 
@@ -54,13 +52,12 @@ calling conventions, making them composable in Effect pipelines.
 
 ### Implementation Details
 
-- All dual functions use `Function.dual(2, ...)` enabling both `findNode(root, path)` and
-  `pipe(root, findNode(path))`
+- All dual functions use `Function.dual(2, ...)` enabling both `findNode(root, path)` and `pipe(root, findNode(path))`
 - `findNode` navigates property names (strings) and array indices (numbers) in the path
 - `findNodeAtOffset` performs depth-first narrowing to the most specific node covering the offset
 - `getNodePath` computes the JSON path by walking the AST to find the node at the given offset
-- `getNodeValue` recursively evaluates the AST subtree, reconstructing objects, arrays, and
-  primitive values
+- `getNodeValue` recursively evaluates the AST subtree, reconstructing objects, arrays and primitive values
+- Offset-based lookups honor the tight span contract (see [parser.md](parser.md)): node spans exclude trailing whitespace and comments, so an offset in the trivia between a value and its container's closing `}`/`]` resolves to the container, not the preceding value
 
 ### Usage Example
 
@@ -92,19 +89,16 @@ const value = pipe(
 
 ### Function.dual
 
-`Function.dual` enables both calling conventions without maintaining separate implementations.
-The arity argument (2) tells Effect how many arguments the data-first form expects. This is
-idiomatic Effect-TS and allows AST navigation to integrate naturally with `pipe` and `Effect.gen`.
+`Function.dual` enables both calling conventions without maintaining separate implementations. The arity argument (2) tells Effect how many arguments the data-first form expects. This is idiomatic Effect-TS and allows AST navigation to integrate naturally with `pipe` and `Effect.gen`.
 
 ### Option.Option Return Types
 
-Navigation functions return `Option<JsoncNode>` rather than throwing or returning `undefined`,
-making the "not found" case explicit and composable with Effect's `Option` combinators.
+Navigation functions return `Option<JsoncNode>` rather than throwing or returning `undefined`, making the "not found" case explicit and composable with Effect's `Option` combinators.
 
 ---
 
 ## Related Documentation
 
 - [Architecture](architecture.md) -- System overview and AST navigation pipeline diagram
-- [Parser](parser.md) -- parseTree() that produces the AST
+- [Parser](parser.md) -- parseTree() that produces the AST and the tight span contract
 - [Effect Patterns](effect-patterns.md) -- Function.dual pattern details

--- a/.claude/design/jsonc-effect/formatting.md
+++ b/.claude/design/jsonc-effect/formatting.md
@@ -3,12 +3,13 @@ status: current
 module: jsonc-effect
 category: architecture
 created: 2026-03-12
-updated: 2026-03-13
-last-synced: 2026-03-13
+updated: 2026-07-06
+last-synced: 2026-07-06
 completeness: 95
 related:
   - architecture.md
   - scanner.md
+  - parser.md
   - effect-patterns.md
 dependencies:
   - scanner.md
@@ -16,8 +17,7 @@ dependencies:
 
 # Formatting and Modification
 
-Compute edit operations for JSONC documents without mutation -- format, modify, and apply edits
-as a pure data pipeline.
+Compute edit operations for JSONC documents without mutation -- format, modify, and apply edits as a pure data pipeline.
 
 ## Table of Contents
 
@@ -30,9 +30,7 @@ as a pure data pipeline.
 
 ## Overview
 
-The formatting module (`format.ts`) provides functions for formatting JSONC documents and computing
-document modifications. All operations produce arrays of `JsoncEdit` objects rather than mutating
-text directly, fitting naturally into Effect's functional style.
+The formatting module (`format.ts`) provides functions for formatting JSONC documents and computing document modifications. All operations produce arrays of `JsoncEdit` objects rather than mutating text directly, fitting naturally into Effect's functional style.
 
 **When to reference this document:**
 
@@ -58,8 +56,7 @@ text directly, fitting naturally into Effect's functional style.
 
 **Format:**
 
-- Uses `createScanner(text, false)` to walk all tokens, computing indentation edits by comparing
-  gap text between tokens against expected whitespace
+- Uses `createScanner(text, false)` to walk all tokens, computing indentation edits by comparing gap text between tokens against expected whitespace
 - Supports range formatting (format only a portion of the document)
 - `keepLines` mode preserves existing line breaks
 - Configurable `tabSize`, `insertSpaces`, `eol`, and `insertFinalNewline`
@@ -68,6 +65,8 @@ text directly, fitting naturally into Effect's functional style.
 
 - Uses `createScanner(text, true)` (ignoreTrivia=true) to navigate to the target path
 - Computes replacement, insertion, or removal edits based on the target value
+- Edits are **byte-minimal**: replacement spans end at the last token of the target value, never absorbing trailing whitespace or comments (issue #62). The internal `skipValue()` returns the tight end offset of the skipped value; using the next token's offset instead would overshoot because the ignoreTrivia scanner silently skips whitespace when advancing
+- Insertion of a new property appends `,\n<indent>"key": ...` directly after the last existing value, preserving the newline-before-closing-brace layout
 - Supports `Function.dual` with arity detection via `typeof args[0] === "string" && Array.isArray(args[1])`
 - Returns `Effect<JsoncEdit[], JsoncModificationError>` when the path cannot be navigated
 
@@ -121,11 +120,13 @@ Producing `JsoncEdit[]` rather than mutated strings enables:
 - Applying edits in the correct order (reverse offset)
 - Natural fit with Effect's functional programming model
 
+### Byte-Minimal Edits
+
+Modification edits touch only the bytes of the value being replaced. Earlier behavior computed the replacement span from the next scanned token's offset, which swallowed the whitespace between the last value and a closing `}` or `]` -- editing `"version"` in a pretty-printed file collapsed the trailing newline (issue #62). Byte-minimal spans keep in-place edits diff-friendly and preserve the surrounding layout exactly. This mirrors the tight node span contract in the [parser](parser.md).
+
 ### Separate Scanner Modes
 
-Format uses `ignoreTrivia=false` to analyze whitespace gaps between tokens. Modify uses
-`ignoreTrivia=true` for simplified path navigation. This separation keeps each function focused
-on its specific concern.
+Format uses `ignoreTrivia=false` to analyze whitespace gaps between tokens. Modify uses `ignoreTrivia=true` for simplified path navigation. This separation keeps each function focused on its specific concern.
 
 ---
 
@@ -133,4 +134,5 @@ on its specific concern.
 
 - [Architecture](architecture.md) -- System overview and format pipeline diagram
 - [Scanner](scanner.md) -- Token stream used for edit computation
+- [Parser](parser.md) -- Tight node span semantics that modify's edits mirror
 - [Effect Patterns](effect-patterns.md) -- Function.dual pattern details

--- a/.claude/design/jsonc-effect/parser.md
+++ b/.claude/design/jsonc-effect/parser.md
@@ -3,12 +3,13 @@ status: current
 module: jsonc-effect
 category: architecture
 created: 2026-03-12
-updated: 2026-03-13
-last-synced: 2026-03-13
+updated: 2026-07-06
+last-synced: 2026-07-06
 completeness: 95
 related:
   - architecture.md
   - scanner.md
+  - formatting.md
   - error-types.md
   - effect-patterns.md
 dependencies:
@@ -18,8 +19,7 @@ dependencies:
 
 # Parser
 
-Recursive descent parser that consumes the scanner's token stream and produces either JavaScript
-values or AST nodes.
+Recursive descent parser that consumes the scanner's token stream and produces either JavaScript values or AST nodes.
 
 ## Table of Contents
 
@@ -32,17 +32,14 @@ values or AST nodes.
 
 ## Overview
 
-The parser (`parse.ts`) is the core of the JSONC processing pipeline. It uses `createScanner` to
-tokenize input and then walks the token stream via mutually recursive functions (`parseValue`,
-`parseObject`, `parseArray` and their tree-building variants). The parser supports two modes:
-value parsing (producing JavaScript values) and tree parsing (producing `JsoncNode` AST).
+The parser (`parse.ts`) is the core of the JSONC processing pipeline. It uses `createScanner` to tokenize input and then walks the token stream via mutually recursive functions (`parseValue`, `parseObject`, `parseArray` and their tree-building variants). The parser supports two modes: value parsing (producing JavaScript values) and tree parsing (producing `JsoncNode` AST).
 
 **When to reference this document:**
 
 - When modifying the recursive descent logic
 - When changing error accumulation behavior
 - When adding support for new JSONC features
-- When debugging parse error handling
+- When debugging parse error handling or node span computation
 
 ---
 
@@ -58,16 +55,20 @@ value parsing (producing JavaScript values) and tree parsing (producing `JsoncNo
 
 ### Implementation Details
 
-- Uses `createScanner(text, false)` (ignoreTrivia=false) so the parser sees comment tokens, which
-  is required to support the `disallowComments` option
-- `token()` getter function defeats TypeScript control-flow narrowing -- necessary because
-  `scanNext()` mutates the current token via closure and TS incorrectly narrows after switch cases
-- Error accumulation: the parser collects all errors into an array and continues parsing rather
-  than stopping at the first error, using skip-until recovery strategies
-- `parseTree` builds AST using mutable internal `MutableJsoncNode` interface, then casts to the
-  immutable `JsoncNode` Schema.Class at boundaries
-- `stripComments` uses a separate scanner pass with `ignoreTrivia=true`, replacing comment spans
-  with the optional replacement character or removing them entirely
+- Uses `createScanner(text, false)` (ignoreTrivia=false) so the parser sees comment tokens, which is required to support the `disallowComments` option
+- `token()` getter function defeats TypeScript control-flow narrowing -- necessary because `scanNext()` mutates the current token via closure and TS incorrectly narrows after switch cases
+- Error accumulation: the parser collects all errors into an array and continues parsing rather than stopping at the first error, using skip-until recovery strategies
+- `parseTree` builds AST using mutable internal `MutableJsoncNode` interface, then casts to the immutable `JsoncNode` Schema.Class at boundaries
+- `stripComments` uses a separate scanner pass with `ignoreTrivia=true`, replacing comment spans with the optional replacement character or removing them entirely
+
+### Node Span Semantics (Tight Spans)
+
+`JsoncNode.offset`/`length` spans are **tight**: they end at the last token belonging to the node, excluding any trailing whitespace or comments. This is a behavior contract that `modify` (see [Formatting](formatting.md)) and editor integrations depend on.
+
+- A `tokenEnd()` helper (`getTokenOffset() + getTokenLength()`) captures the end of the current token *before* `scanNext()` advances, because advancing skips trivia and the next token's offset would overshoot the node's true end (issue #62)
+- Value, key, array and object node lengths all derive from the tight end of their last consumed token
+- Property node lengths derive from their value node's end (`valueNode.offset + valueNode.length - property.offset`)
+- On error recovery (missing `}` or `]`), the length falls back to the current token offset
 
 ### Effect Wrapping
 
@@ -97,27 +98,23 @@ export const parse = (text, options?) =>
 
 ### token() Getter Function
 
-TypeScript's control-flow narrowing incorrectly narrows the token type after switch cases in the
-parser, because `scanNext()` mutates `currentToken` via closure. The `token()` getter function
-defeats this narrowing cleanly, making the mutation semantics explicit without scattered type
-assertions.
+TypeScript's control-flow narrowing incorrectly narrows the token type after switch cases in the parser, because `scanNext()` mutates `currentToken` via closure. The `token()` getter function defeats this narrowing cleanly, making the mutation semantics explicit without scattered type assertions.
 
 ### Error Accumulation
 
-Stopping at the first error provides poor user experience for config file parsing. Accumulating all
-errors lets tooling show all issues at once, similar to how IDEs report multiple diagnostics. The
-parser continues past errors using skip-until recovery strategies.
+Stopping at the first error provides poor user experience for config file parsing. Accumulating all errors lets tooling show all issues at once, similar to how IDEs report multiple diagnostics. The parser continues past errors using skip-until recovery strategies.
+
+### Tight Node Spans
+
+Node spans previously ran to the offset of the next scanned token, silently absorbing trailing whitespace and comments into the node. That made spans useless for byte-minimal editing: replacing the last value before a closing `}` or `]` swallowed the intervening newline (issue #62). Tight spans make `offset`/`length` describe exactly the node's own text, which is what editors, `modify` and slice-based consumers expect.
 
 ### ignoreTrivia=false
 
-The parser uses `ignoreTrivia=false` so it can see comment tokens. This is required to detect and
-report comments when `disallowComments` is true. The parser's `scanNext()` loop handles trivia
-tokens explicitly, skipping them during normal parsing.
+The parser uses `ignoreTrivia=false` so it can see comment tokens. This is required to detect and report comments when `disallowComments` is true. The parser's `scanNext()` loop handles trivia tokens explicitly, skipping them during normal parsing.
 
 ### allowTrailingComma Defaults to true
 
-Unlike Microsoft's jsonc-parser which defaults to false, this package defaults to true because
-the primary use case is parsing JSONC config files where trailing commas are standard.
+Unlike Microsoft's jsonc-parser which defaults to false, this package defaults to true because the primary use case is parsing JSONC config files where trailing commas are standard.
 
 ---
 
@@ -125,5 +122,6 @@ the primary use case is parsing JSONC config files where trailing commas are sta
 
 - [Architecture](architecture.md) -- System overview and data flow
 - [Scanner](scanner.md) -- Token stream that the parser consumes
+- [Formatting](formatting.md) -- modify() relies on tight span semantics
 - [Error Types](error-types.md) -- JsoncParseError and error detail structure
 - [Effect Patterns](effect-patterns.md) -- Effect.sync wrapping pattern

--- a/.claude/design/refs.json
+++ b/.claude/design/refs.json
@@ -1,0 +1,65 @@
+{
+	"version": 1,
+	"refs": [
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/architecture.md",
+			"hash": "afc1dec073cdf2588aba182716153eff9e5d96a942f8ece8689f47187b459ae3",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/ast-navigation.md",
+			"hash": "1e763e0f4f7ed2393eccd7f7e898d31876e4d754b7284f7352d4ea83045388f6",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/effect-patterns.md",
+			"hash": "99bf8f2819c5155b2e5123a192be05640aaf322467e24ca312288ae93fc41ae6",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/equality.md",
+			"hash": "b6995821b24af71859bb7b2a6ff68c9e6b6a414687e0d252015f4a81a7955f73",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/error-types.md",
+			"hash": "188dab2bc3a95ae3a70836d5c58dd79c96ac86787498f1eb222f03f5870c6cf4",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/formatting.md",
+			"hash": "194824d0ed3e3a64f4b14beaf42cfef1efc43943b28f7f8df4ff99f4bfc68745",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/parser.md",
+			"hash": "81c6e854bb43f74a61af092e39057200e849fbd261e6de4cfb7be773f69ac8d2",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/scanner.md",
+			"hash": "8626e574c50c868757b985a2e2b6fa051435832135bc0e1ef419ad5dc1140787",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/schema-integration.md",
+			"hash": "4866487f6c34e6842595243c4179208acc187d4428af3634cbf62de74120b9aa",
+			"recordedAt": "2026-07-06"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/jsonc-effect/visitor.md",
+			"hash": "973a5eb48a40bb32cc52321f62252aadef139b40b087e4578b2d7c9777ba28ba",
+			"recordedAt": "2026-07-06"
+		}
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pnpm-release.json
 
 # Claude AI files
 .claude/settings.local.json
+.claude/cache/
 .claude/plans/
 .claude/plugins-debug.log
 .playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Load when working on system architecture, module structure, or major refactoring
 -> `@./.claude/design/jsonc-effect/ast-navigation.md` — AST traversal utilities
 -> `@./.claude/design/jsonc-effect/visitor.md` — SAX-style event stream
 -> `@./.claude/design/jsonc-effect/formatting.md` — Format/modify/applyEdits
+-> `@./.claude/design/jsonc-effect/equality.md` — Semantic equality (equals/equalsValue)
 -> `@./.claude/design/jsonc-effect/error-types.md` — TaggedError patterns
 -> `@./.claude/design/jsonc-effect/effect-patterns.md` — Effect-TS patterns used
 Load specific component docs when modifying that component's implementation.
@@ -42,6 +43,7 @@ Load specific component docs when modifying that component's implementation.
 - `Schema.Class` for structural equality on tokens, nodes, options
 - String literals for token types (not numeric enums)
 - `allowTrailingComma` defaults to `true`
+- Tight node spans — `JsoncNode` offset/length end at the node's last token (trailing whitespace/comments excluded), so `modify` emits byte-minimal edits and offset lookups in trivia resolve to the container
 - Platform independent — no `node:` imports anywhere
 
 ### Source Structure
@@ -56,6 +58,7 @@ src/
 ├── ast.ts                 # findNode, findNodeAtOffset, getNodePath, getNodeValue
 ├── visitor.ts             # visit(), visitCollect(), JsoncVisitorEvent stream API
 ├── format.ts              # format(), modify(), applyEdits(), formatAndApply()
+├── equality.ts            # equals(), equalsValue() — semantic comparison
 └── index.ts               # Barrel exports
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # jsonc-effect
 
-[![npm version](https://img.shields.io/npm/v/jsonc-effect)](https://www.npmjs.com/package/jsonc-effect)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
+[![npm](https://img.shields.io/npm/v/jsonc-effect?label=npm&color=cb3837)](https://www.npmjs.com/package/jsonc-effect)
+[![License: MIT](https://img.shields.io/badge/License-MIT-4caf50.svg)](https://opensource.org/licenses/MIT)
+[![Node.js %3E%3D24.11.0](https://img.shields.io/badge/Node.js-%3E%3D24.11.0-5fa04e.svg)](https://nodejs.org/)
+[![TypeScript 6.0](https://img.shields.io/badge/TypeScript-6.0-3178c6.svg)](https://www.typescriptlang.org/)
 
-Pure [Effect](https://effect.website) JSONC (JSON with Comments) parser with no external parser dependencies. Scanner, parser, AST, and formatting are all implemented natively.
+Pure [Effect](https://effect.website) JSONC (JSON with Comments) parser with no external parser dependencies. Scanner, parser, AST and formatting are all implemented natively.
 
 ## Features
 
-- **Effect-native** -- typed errors, Schema integration, and composable pipelines
+- **Effect-native** -- typed errors, Schema integration and composable pipelines
 - **Zero parser dependencies** -- `effect` is the sole runtime dependency
 - **Schema integration** -- parse JSONC strings directly into validated types
-- **Full toolchain** -- scanner, parser, AST navigation, visitor stream, formatting, and modification
-- **Equality comparisons** -- compare JSONC documents semantically, ignoring comments, formatting, and key ordering
+- **Full toolchain** -- scanner, parser, AST navigation, visitor stream, formatting and modification
+- **Byte-minimal edits** -- `modify` targets exactly the value's span, preserving surrounding whitespace and comments
+- **Equality comparisons** -- compare JSONC documents semantically, ignoring comments, formatting and key ordering
 - **Safe by default** -- returns `unknown` (not `any`) and `Option` (not `undefined`)
 
-## Installation
+## Install
 
 ```bash
 npm install jsonc-effect effect
+# or
+pnpm add jsonc-effect effect
 ```
 
-## Quick Start
+## Quick start
 
 ```typescript
 import { parse } from "jsonc-effect"
@@ -59,8 +63,10 @@ This library is for Effect-based programs that need deeper introspection and edi
 
 ## Documentation
 
-For API reference, advanced usage, and examples, see [docs](./docs/README.md).
+- [Getting started](./docs/01-getting-started.md) — installation, first example, core concepts
+- [Examples](./docs/02-examples.md) — real-world usage patterns
+- [API reference](./docs/03-api-reference.md) — all exports with signatures and descriptions
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](LICENSE)

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -1,9 +1,11 @@
-# Getting Started
+# Getting started
 
-## Installation
+## Install
 
 ```bash
 npm install jsonc-effect effect
+# or
+pnpm add jsonc-effect effect
 ```
 
 Both `jsonc-effect` and `effect` are required. The `effect` package is the sole runtime dependency.
@@ -93,5 +95,5 @@ const result = Effect.runSync(program)
 
 ## Next steps
 
-- [API Reference](./api.md) -- all exports with signatures
-- [Examples](./examples.md) -- real-world usage patterns
+- [Examples](./02-examples.md) -- real-world usage patterns
+- [API reference](./03-api-reference.md) -- all exports with signatures

--- a/docs/02-examples.md
+++ b/docs/02-examples.md
@@ -51,6 +51,22 @@ const result = Effect.runSync(
 // => '{ "version": 2, "name": "app" }'
 ```
 
+Edits are byte-minimal: replacing a value touches exactly the value's span, so comments, indentation and the layout around closing braces survive the round trip.
+
+```typescript
+import { modify, applyEdits } from "jsonc-effect"
+import { Effect } from "effect"
+
+const input = '{\n\t"version": "1.0.0"\n}\n'
+
+const result = Effect.runSync(
+  modify(input, ["version"], "2.0.0").pipe(
+    Effect.flatMap((edits) => applyEdits(input, edits))
+  )
+)
+// => '{\n\t"version": "2.0.0"\n}\n'
+```
+
 ## Streaming visitor events
 
 ```typescript
@@ -235,7 +251,7 @@ const updated = Effect.runSync(
 )
 ```
 
-## Wrapping in an Effect Service
+## Wrapping in an Effect service
 
 ```typescript
 import { Context, Effect, Layer } from "effect"

--- a/docs/03-api-reference.md
+++ b/docs/03-api-reference.md
@@ -1,4 +1,4 @@
-# API Reference
+# API reference
 
 ## Parser
 
@@ -10,7 +10,7 @@ Parse a JSONC string to a JavaScript value.
 
 ### `parseTree(text, options?)`
 
-Parse a JSONC string to an AST.
+Parse a JSONC string to an AST. Node spans are tight: each node's `offset` and `length` cover exactly the node's own text, excluding any trailing whitespace or comments before the next token.
 
 - **Returns:** `Effect<Option<JsoncNode>, JsoncParseError>`
 
@@ -28,12 +28,9 @@ Create a low-level token scanner.
 
 - **Returns:** `JsoncScanner`
 
-The scanner produces tokens of type `JsoncSyntaxKind`: `OpenBrace`,
-`CloseBrace`, `OpenBracket`, `CloseBracket`, `Comma`, `Colon`, `String`,
-`Number`, `True`, `False`, `Null`, `LineComment`, `BlockComment`,
-`LineBreak`, `Trivia`, `Unknown`, `EOF`.
+The scanner produces tokens of type `JsoncSyntaxKind`: `OpenBrace`, `CloseBrace`, `OpenBracket`, `CloseBracket`, `Comma`, `Colon`, `String`, `Number`, `True`, `False`, `Null`, `LineComment`, `BlockComment`, `LineBreak`, `Trivia`, `Unknown`, `EOF`.
 
-## Schema Integration
+## Schema integration
 
 ### `JsoncFromString`
 
@@ -51,10 +48,9 @@ Compose JSONC parsing with a target Schema for end-to-end typed parsing.
 
 - **Returns:** `Schema<A, string>`
 
-## AST Navigation
+## AST navigation
 
-All navigation functions support `Function.dual` (data-first and data-last
-calling conventions).
+All navigation functions support `Function.dual` (data-first and data-last calling conventions).
 
 ### `findNode(root, path)`
 
@@ -64,13 +60,13 @@ Find node at a JSON path.
 
 ### `findNodeAtOffset(root, offset)`
 
-Find innermost node at a character offset.
+Find innermost node at a character offset. Offsets that land in trailing whitespace or comments after a value resolve to the enclosing container, not the preceding value.
 
 - **Returns:** `Effect<Option<JsoncNode>>`
 
 ### `getNodePath(root, offset)`
 
-Get the JSON path to the node at a given offset.
+Get the JSON path to the node at a given offset. Uses the same offset resolution as `findNodeAtOffset`.
 
 - **Returns:** `Effect<Option<JsoncPath>>`
 
@@ -80,7 +76,7 @@ Reconstruct a JavaScript value from an AST node.
 
 - **Returns:** `Effect<unknown>`
 
-## Formatting and Modification
+## Formatting and modification
 
 ### `format(text, range?, options?)`
 
@@ -102,8 +98,7 @@ Format a JSONC document in one step.
 
 ### `modify(text, path, value, options?)`
 
-Compute edits to insert, replace, or remove a value at a JSON path (supports
-`Function.dual`).
+Compute edits to insert, replace, or remove a value at a JSON path (supports `Function.dual`). Edits are byte-minimal: replacing a value touches exactly the value's span, so surrounding whitespace, newlines and comments are preserved.
 
 - **Returns:** `Effect<JsoncEdit[], JsoncModificationError>`
 
@@ -111,9 +106,7 @@ Compute edits to insert, replace, or remove a value at a JSON path (supports
 
 ### `equals(self, that)`
 
-Compare two JSONC strings for semantic equality. Parses both strings and
-deep-compares the resulting values. Ignores comments, whitespace, formatting,
-and object key ordering. Array order is significant.
+Compare two JSONC strings for semantic equality. Parses both strings and deep-compares the resulting values. Ignores comments, whitespace, formatting and object key ordering. Array order is significant.
 
 Supports `Function.dual` (data-first and data-last).
 
@@ -121,8 +114,7 @@ Supports `Function.dual` (data-first and data-last).
 
 ### `equalsValue(self, value)`
 
-Compare a JSONC string against a JavaScript value. Parses the JSONC string and
-deep-compares against the provided value. Same comparison semantics as `equals`.
+Compare a JSONC string against a JavaScript value. Parses the JSONC string and deep-compares against the provided value. Same comparison semantics as `equals`.
 
 Supports `Function.dual` (data-first and data-last).
 
@@ -136,8 +128,7 @@ Stream of SAX-style visitor events.
 
 - **Returns:** `Stream<JsoncVisitorEvent>`
 
-Event types: `ObjectBegin`, `ObjectEnd`, `ObjectProperty`, `ArrayBegin`,
-`ArrayEnd`, `LiteralValue`, `Separator`, `Comment`, `Error`.
+Event types: `ObjectBegin`, `ObjectEnd`, `ObjectProperty`, `ArrayBegin`, `ArrayEnd`, `LiteralValue`, `Separator`, `Comment`, `Error`.
 
 ### `visitCollect(text, predicate, options?)`
 
@@ -149,7 +140,7 @@ Collect filtered visitor events into an array.
 
 | Type | Description |
 | --- | --- |
-| `JsoncNode` | AST node with type, offset, length, value, children |
+| `JsoncNode` | AST node with type, offset, length, value, children; spans are tight (no trailing trivia) |
 | `JsoncEdit` | Text edit: offset, length, content |
 | `JsoncRange` | Document range: offset, length |
 | `JsoncToken` | Scanner token: kind, value, offset, length |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,20 @@
-# jsonc-effect Documentation
+# jsonc-effect documentation
+
+Pure [Effect](https://effect.website) JSONC (JSON with Comments) parser with no external parser dependencies. Scanner, parser, AST and formatting are all implemented natively.
+
+## Install
+
+```bash
+npm install jsonc-effect effect
+# or
+pnpm add jsonc-effect effect
+```
 
 ## Guides
 
-- [Getting Started](./getting-started.md) -- installation, first example, core concepts
-- [API Reference](./api.md) -- all exports with signatures and descriptions
-- [Examples](./examples.md) -- real-world usage patterns
+- [Getting started](./01-getting-started.md) — installation, first example, core concepts
+- [Examples](./02-examples.md) — real-world usage patterns
+- [API reference](./03-api-reference.md) — all exports with signatures and descriptions
 
 ## Overview
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -396,9 +396,22 @@ function modifyImpl(
 	const scanner = createScanner(text, true);
 	let currentToken = scanner.scan();
 
-	function skipValue(): void {
+	// Tight end-of-token offset for the CURRENT token. Because this scanner is
+	// created with ignoreTrivia=true, scan() silently skips whitespace when
+	// advancing — so getTokenOffset() *after* advancing gives the start of the
+	// NEXT token, past any trailing trivia, not the end of the token we just
+	// left. Capture this value before advancing (see issue #62).
+	function tokenEnd(): number {
+		return scanner.getTokenOffset() + scanner.getTokenLength();
+	}
+
+	// Skips over the value starting at currentToken and returns the tight end
+	// offset (excluding trailing whitespace/comments) of the last token
+	// belonging to that value.
+	function skipValue(): number {
 		switch (currentToken) {
 			case "OpenBrace": {
+				let end = tokenEnd();
 				currentToken = scanner.scan();
 				let first = true;
 				while (currentToken !== "CloseBrace" && currentToken !== "EOF") {
@@ -409,36 +422,42 @@ function modifyImpl(
 						currentToken = scanner.scan(); // skip key
 						if (currentToken === "Colon") {
 							currentToken = scanner.scan(); // skip colon
-							skipValue(); // skip value
+							end = skipValue(); // skip value
 						}
 					} else {
+						end = tokenEnd();
 						currentToken = scanner.scan();
 					}
 					first = false;
 				}
 				if (currentToken === "CloseBrace") {
+					end = tokenEnd();
 					currentToken = scanner.scan();
 				}
-				break;
+				return end;
 			}
 			case "OpenBracket": {
+				let end = tokenEnd();
 				currentToken = scanner.scan();
 				let first = true;
 				while (currentToken !== "CloseBracket" && currentToken !== "EOF") {
 					if (!first && currentToken === "Comma") {
 						currentToken = scanner.scan();
 					}
-					skipValue();
+					end = skipValue();
 					first = false;
 				}
 				if (currentToken === "CloseBracket") {
+					end = tokenEnd();
 					currentToken = scanner.scan();
 				}
-				break;
+				return end;
 			}
-			default:
+			default: {
+				const end = tokenEnd();
 				currentToken = scanner.scan();
-				break;
+				return end;
+			}
 		}
 	}
 
@@ -472,8 +491,7 @@ function modifyImpl(
 							// This is our target
 							const valueStart = scanner.getTokenOffset();
 							const prevEnd = valueStart;
-							skipValue();
-							const valueEnd = scanner.getTokenOffset();
+							const valueEnd = skipValue();
 
 							if (value === undefined) {
 								// Remove property — find the key start and handle commas
@@ -510,11 +528,11 @@ function modifyImpl(
 						}
 						break;
 					}
-					skipValue();
+					lastValueEnd = skipValue();
 				} else {
 					currentToken = scanner.scan();
+					lastValueEnd = scanner.getTokenOffset();
 				}
-				lastValueEnd = scanner.getTokenOffset();
 				isFirst = false;
 			}
 
@@ -543,8 +561,7 @@ function modifyImpl(
 				if (idx === segment) {
 					if (depth === path.length) {
 						const valueStart = scanner.getTokenOffset();
-						skipValue();
-						const valueEnd = scanner.getTokenOffset();
+						const valueEnd = skipValue();
 
 						if (value === undefined) {
 							// Remove element
@@ -561,8 +578,7 @@ function modifyImpl(
 					}
 					break;
 				}
-				skipValue();
-				lastEnd = scanner.getTokenOffset();
+				lastEnd = skipValue();
 				idx++;
 			}
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -381,6 +381,74 @@ describe("parseTree", () => {
 });
 
 // ============================================================
+// parseTree — tight node spans (issue #62)
+// ============================================================
+
+describe("parseTree — tight node spans (issue #62)", () => {
+	it("string value node span excludes trailing whitespace before closing brace with newline", async () => {
+		const input = '{\n\t"version": "1.0.0"\n}\n';
+		const result = await Effect.runPromise(parseTree(input));
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			const root = result.value;
+			const children = root.children ?? [];
+			const property = children[0];
+			const propChildren = property.children ?? [];
+			const valueNode = propChildren[1];
+			expect(input.slice(valueNode.offset, valueNode.offset + valueNode.length)).toBe('"1.0.0"');
+		}
+	});
+
+	it("property node span ends at its value's tight end, excluding trailing whitespace", async () => {
+		const input = '{\n\t"version": "1.0.0"\n}\n';
+		const result = await Effect.runPromise(parseTree(input));
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			const root = result.value;
+			const property = (root.children ?? [])[0];
+			expect(input.slice(property.offset, property.offset + property.length)).toBe('"version": "1.0.0"');
+		}
+	});
+
+	it("array node span excludes trailing whitespace before closing bracket with a space", async () => {
+		const input = "[1, 2 ]";
+		const result = await Effect.runPromise(parseTree(input));
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			const root = result.value;
+			expect(input.slice(root.offset, root.offset + root.length)).toBe("[1, 2 ]");
+			const lastElement = (root.children ?? [])[1];
+			expect(input.slice(lastElement.offset, lastElement.offset + lastElement.length)).toBe("2");
+		}
+	});
+
+	it("nested object node span excludes trailing whitespace before array's closing bracket", async () => {
+		const input = '[ { "a": 1 } ]';
+		const result = await Effect.runPromise(parseTree(input));
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			const root = result.value;
+			const nestedObject = (root.children ?? [])[0];
+			expect(nestedObject.type).toBe("object");
+			expect(input.slice(nestedObject.offset, nestedObject.offset + nestedObject.length)).toBe('{ "a": 1 }');
+		}
+	});
+
+	it("value node span excludes trailing line comments that follow it", async () => {
+		const input = '{ "a": 1 // trailing comment\n}';
+		const result = await Effect.runPromise(parseTree(input));
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			const root = result.value;
+			const property = (root.children ?? [])[0];
+			const valueNode = (property.children ?? [])[1];
+			expect(input.slice(valueNode.offset, valueNode.offset + valueNode.length)).toBe("1");
+			expect(input.slice(property.offset, property.offset + property.length)).toBe('"a": 1');
+		}
+	});
+});
+
+// ============================================================
 // stripComments Tests
 // ============================================================
 
@@ -1155,6 +1223,38 @@ describe("modify — data-last (pipe)", () => {
 		);
 		const parsed = JSON.parse(result);
 		expect(parsed.x).toBe(2);
+	});
+});
+
+// ============================================================
+// modify — byte-minimal edits (issue #62)
+// ============================================================
+
+describe("modify — byte-minimal edits (issue #62)", () => {
+	it("replaces an object property value byte-for-byte, preserving the newline before the closing brace", async () => {
+		const input = '{\n\t"version": "1.0.0"\n}\n';
+		const result = await Effect.runPromise(
+			modify(input, ["version"], "2.0.0").pipe(Effect.flatMap((edits) => applyEdits(input, edits))),
+		);
+		expect(result).toBe('{\n\t"version": "2.0.0"\n}\n');
+	});
+
+	it("replaces an array element value byte-for-byte, preserving the whitespace before the closing bracket", async () => {
+		const input = '{\n\t"items": [\n\t\t1,\n\t\t2\n\t]\n}\n';
+		const result = await Effect.runPromise(
+			modify(input, ["items", 1], 99).pipe(Effect.flatMap((edits) => applyEdits(input, edits))),
+		);
+		expect(result).toBe('{\n\t"items": [\n\t\t1,\n\t\t99\n\t]\n}\n');
+	});
+
+	it("inserts a new property directly after the last value, preserving the newline-before-brace layout", async () => {
+		const input = '{\n\t"pkg": "a"\n}\n';
+		const result = await Effect.runPromise(
+			modify(input, ["version"], "1.0.0", { formattingOptions: { insertSpaces: false } }).pipe(
+				Effect.flatMap((edits) => applyEdits(input, edits)),
+			),
+		);
+		expect(result).toBe('{\n\t"pkg": "a",\n\t"version": "1.0.0"\n}\n');
 	});
 });
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -318,6 +318,14 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 		}
 	}
 
+	// Tight end-of-token offset — captures where the CURRENT token ends,
+	// before scanNext() advances past any trailing trivia. Node lengths are
+	// computed from this value (not from the next token's offset) so spans
+	// never swallow trailing whitespace or comments (see issue #62).
+	function tokenEnd(): number {
+		return scanner.getTokenOffset() + scanner.getTokenLength();
+	}
+
 	function handleError(
 		code: JsoncParseErrorDetail["code"],
 		skipUntilAfter: JsoncSyntaxKind[] = [],
@@ -479,8 +487,9 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 					length: 0,
 					value: scanner.getTokenValue(),
 				};
+				const end = tokenEnd();
 				scanNext();
-				node.length = scanner.getTokenOffset() - node.offset;
+				node.length = end - node.offset;
 				return node as JsoncNode;
 			}
 			case "Number": {
@@ -490,8 +499,9 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 					length: 0,
 					value: Number.parseFloat(scanner.getTokenValue()),
 				};
+				const end = tokenEnd();
 				scanNext();
-				node.length = scanner.getTokenOffset() - node.offset;
+				node.length = end - node.offset;
 				return node as JsoncNode;
 			}
 			case "True": {
@@ -501,8 +511,9 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 					length: 0,
 					value: true,
 				};
+				const end = tokenEnd();
 				scanNext();
-				node.length = scanner.getTokenOffset() - node.offset;
+				node.length = end - node.offset;
 				return node as JsoncNode;
 			}
 			case "False": {
@@ -512,8 +523,9 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 					length: 0,
 					value: false,
 				};
+				const end = tokenEnd();
 				scanNext();
-				node.length = scanner.getTokenOffset() - node.offset;
+				node.length = end - node.offset;
 				return node as JsoncNode;
 			}
 			case "Null": {
@@ -523,8 +535,9 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 					length: 0,
 					value: null,
 				};
+				const end = tokenEnd();
 				scanNext();
-				node.length = scanner.getTokenOffset() - node.offset;
+				node.length = end - node.offset;
 				return node as JsoncNode;
 			}
 			default:
@@ -563,12 +576,15 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 			needsComma = true;
 		}
 
+		let end: number;
 		if (token() !== "CloseBracket") {
 			handleError("CloseBracketExpected");
+			end = scanner.getTokenOffset();
 		} else {
+			end = tokenEnd();
 			scanNext();
 		}
-		node.length = scanner.getTokenOffset() - node.offset;
+		node.length = end - node.offset;
 		return node as JsoncNode;
 	}
 
@@ -611,8 +627,9 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 				length: 0,
 				value: scanner.getTokenValue(),
 			};
+			const keyEnd = tokenEnd();
 			scanNext();
-			keyNode.length = scanner.getTokenOffset() - keyNode.offset;
+			keyNode.length = keyEnd - keyNode.offset;
 			(property.children as MutableJsoncNode[]).push(keyNode);
 
 			if (token() !== "Colon") {
@@ -627,20 +644,24 @@ function parseInternal(text: string, options: Partial<JsoncParseOptions>, buildT
 			const valueNode = parseValueTree();
 			if (valueNode) {
 				(property.children as MutableJsoncNode[]).push(valueNode as MutableJsoncNode);
+				property.length = valueNode.offset + valueNode.length - property.offset;
 			} else {
 				handleError("ValueExpected", [], ["CloseBrace", "Comma"]);
+				property.length = scanner.getTokenOffset() - property.offset;
 			}
-			property.length = scanner.getTokenOffset() - property.offset;
 			(node.children as MutableJsoncNode[]).push(property);
 			needsComma = true;
 		}
 
+		let end: number;
 		if (token() !== "CloseBrace") {
 			handleError("CloseBraceExpected");
+			end = scanner.getTokenOffset();
 		} else {
+			end = tokenEnd();
 			scanNext();
 		}
-		node.length = scanner.getTokenOffset() - node.offset;
+		node.length = end - node.offset;
 		return node as JsoncNode;
 	}
 


### PR DESCRIPTION
## Summary

Fixes the span over-reach reported in #62: both `parseTree` node spans and `modify` value spans previously ran to the offset of the **next** scanned token, past any trailing whitespace or comments. Replacing the last value before a closing `}`/`]` therefore deleted the layout before the closer, making byte-for-byte in-place edits impossible.

## Changes

- **`src/parse.ts`** — node lengths now end at the last consumed token (`tokenEnd()` captured before the scanner advances) instead of the next token's offset; property node lengths derive from their value node's end. `JsoncNode` offset/length spans are now tight, and `findNodeAtOffset`/`getNodePath` resolve offsets in trailing trivia to the container rather than the preceding value.
- **`src/format.ts`** — `skipValue()` in `modifyImpl` returns the tight end offset; the object-property and array-element replacement branches use it, so `modify` + `applyEdits` emit byte-minimal edits. Property insertion now appends `,\n<indent>"key": ...` directly after the last value, preserving the newline-before-brace layout (the secondary bug in #62).
- **`src/index.test.ts`** — 8 new tests covering tight spans (values, properties, arrays, nested objects, trailing comments) and byte-minimal replace/insert round-trips using the exact repro cases from the issue.
- **Docs** — design docs, CLAUDE.md, README, and the docs/ pages updated to document the tight-span contract; docs pages renamed to the numbered convention.
- **Changeset** — `patch` bump for `jsonc-effect` (behavior-only fix, no API changes). Downstream consumers using the `trimEnd()` workaround are unaffected — the trim becomes a no-op.

## Verification

- Full suite: 239/239 tests pass; lint and typecheck clean.
- Ran the issue's repro end-to-end: `modify(doc, ["version"], "2.0.0")` + `applyEdits` on `'{\n\t"version": "1.0.0"\n}\n'` yields byte-exact `'{\n\t"version": "2.0.0"\n}\n'`; node spans slice to `"1.0.0"` with no trailing newline; array-element edits preserve whitespace before the closer.

Closes #62

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSONC editing so changes preserve surrounding formatting and whitespace more reliably.
  * Fixed node span calculations so parsed values and containers exclude trailing trivia like spaces and comments.
* **Documentation**
  * Updated the README and docs with clearer installation steps, refreshed navigation, and expanded API/examples content.
  * Added a new example showing formatting-preserving JSONC edits.
* **Chores**
  * Updated ignored files to exclude local cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->